### PR TITLE
Support HTML materials

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -66,12 +66,22 @@ body {
 
 .material > a:hover {
     text-decoration: none;
+    cursor: pointer;
     color: rgb(110, 70, 255);
 }
 
 .material {
     padding: 0.1rem 0;
     font-size: 1.1rem;
+}
+
+.material > .html-content {
+    border: 1px solid #95a5a6;
+    padding: 1rem;
+}
+
+.material > .html-content > p {
+    margin: 0;
 }
 
 .cumulative {
@@ -306,6 +316,10 @@ body {
 
 .badge.ppt {
     background-color: #ff6767;
+}
+
+.badge.html {
+    background-color: #008080;
 }
 
 .comment:nth-child(even) {

--- a/src/html/main.html
+++ b/src/html/main.html
@@ -49,8 +49,11 @@
                                 <span class="badge word" v-if="materialType(material) == 'word'">DOC</span>
                                 <span class="badge zip" v-if="materialType(material) == 'zip'">ZIP</span>
                                 <span class="badge ppt" v-if="materialType(material) == 'ppt'">PPT</span>
-                                <a v-bind:href="materialLink(material)"><span class="title">{{ material.title }}</span></a>
+                                <span class="badge html" v-if="materialType(material) == 'html'">HTML</span>
+                                <a v-if="materialType(material) != 'html'" v-bind:href="materialLink(material)"><span class="title">{{ material.title }}</span></a>
+                                <a v-if="materialType(material) == 'html'" v-on:click="toggleHTML(material)"><span class="title">{{ material.title }}</span></a>
                                 <div class="description">{{ material.description }}</div>
+                                <div v-if="materialType(material) == 'html'" class="html-content" v-bind:id="material.id" hidden></div>
                             </div>
                         </div>
                     </div>

--- a/src/main.js
+++ b/src/main.js
@@ -129,9 +129,18 @@ ready(() => {
             materialType: function(material) {
                 if (!getSetting("showTypes")) return "";
 
-                if (material.type == "url") return "url";
+                if (["url", "html"].includes(material.type)) return material.type;
                 if (material.type == "document") return mimeTypeShortDescription(material.mimeType);
                 return "";
+            },
+            toggleHTML: function(material) {
+                const content = document.getElementById(material.id);
+                content.hidden = !content.hidden;
+                if (!content.innerHTML) {
+                    get(material.downloadUrl, (res) => {
+                        content.innerHTML = res;
+                    });
+                }
             },
             commentType: function(comment) {
                 return comment.type;

--- a/src/main.js
+++ b/src/main.js
@@ -134,9 +134,12 @@ ready(() => {
                 return "";
             },
             toggleHTML: function(material) {
+                const loadingText = "<p>Loading...</p>";
                 const content = document.getElementById(material.id);
                 content.hidden = !content.hidden;
-                if (!content.innerHTML) {
+                // check if equals loadingText in case previous request to downloadUrl failed
+                if (!content.innerHTML || content.innerHTML == loadingText) {
+                    content.innerHTML = loadingText;
                     get(material.downloadUrl, (res) => {
                         content.innerHTML = res;
                     });


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/8326522/75297847-eb58da80-57fe-11ea-8f56-e02e7e64f19f.png)

Now:
![image](https://user-images.githubusercontent.com/8326522/75297895-04fa2200-57ff-11ea-9846-0bc915fc4350.png)

The HTML content can also be toggled by clicking the title.